### PR TITLE
Oop

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,9 +10,9 @@
 #                                                                              #
 # **************************************************************************** #
 
-CC = gcc -O3
+CC = gcc
 
-CFLAGS = -Wall -Wextra -Werror -g -Ofast -Isources
+CFLAGS = -Wall -Wextra -Werror -g -Isources
 
 LDFLAGS =
 

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@
 
 CC = gcc
 
-CFLAGS = -Wall -Wextra -Werror -g -Isources
+CFLAGS = -Wall -Wextra -Werror -g -Isources -O3 -Ofast
 
 LDFLAGS =
 

--- a/dep/so_long.h
+++ b/dep/so_long.h
@@ -6,7 +6,7 @@
 /*   By: yiwong <yiwong@student.42wolfsburg.de>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/05/29 15:54:16 by yiwong            #+#    #+#             */
-/*   Updated: 2023/06/13 19:15:51 by yiwong           ###   ########.fr       */
+/*   Updated: 2023/06/14 00:20:26 by kschmidt         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -47,25 +47,21 @@ typedef struct	s_vars {
 	int		map_height;
 }				t_vars;
 
-enum	e_keycodes {
-	ESC = 53,
-	W = 13,
-	A = 0,
-	S = 1,
-	D = 2
-};
+# define ESC 53
+# define W 13
+# define A 0
+# define S 1
+# define D 2
 
-enum	e_errorcodes {
-	OK = 0,
-	FAIL = -1,
-	ARGN = 11,
-	MAP_NAME = 12,
-	BAD_MAP = 13
-};
+# define OK 0
+# define FAIL (-1)
+# define ARGN 11
+# define MAP_NAME 12
+# define BAD_MAP 1
 
-#define red 0x00FF0000
-#define green 0x0000FF00
-#define blue 0x000000FF
+# define red 0x00FF0000
+# define green 0x0000FF00
+# define blue 0x000000FF
 
 int		arg_check(int argc, char **argv);
 

--- a/src/main.c
+++ b/src/main.c
@@ -6,7 +6,7 @@
 /*   By: yiwong <yiwong@student.42wolfsburg.de>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/05/29 15:55:54 by yiwong            #+#    #+#             */
-/*   Updated: 2023/06/13 19:13:25 by yiwong           ###   ########.fr       */
+/*   Updated: 2023/06/14 00:21:17 by kschmidt         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -22,13 +22,24 @@ int	main(int argc, char **argv)
 	int	error_code;
 	t_vars	vars;
 
+	ft_memset(&vars, 0, sizeof(vars));
 	error_code = arg_check(argc, argv);
 	if (error_code != OK)
+	{
 		error(error_code);
+		perror("The given arguments were faulty.");
+		return (1);
+	}
 	if (argc == 1)
 		error_code = init(NULL, &vars);
 	else
 		error_code = init(argv[1], &vars);
+	if (error_code != OK)
+	{
+		error(error_code);
+		perror("The map couldn't be initialized.");
+		return (1);
+	}
 	so_long(&vars);
 	return (0);
 }

--- a/src/quit.c
+++ b/src/quit.c
@@ -24,6 +24,5 @@ void	quit(t_vars *vars)
 	mlx_loop_end(vars->mlx);
 	mlx_destroy_display(vars->mlx);
 	free_ppointer(vars->map);
-	free(vars->mlx);
 	exit(0);
 }

--- a/src/ready_check.c
+++ b/src/ready_check.c
@@ -6,7 +6,7 @@
 /*   By: yiwong <yiwong@student.42wolfsburg.de>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/06/07 17:15:08 by yiwong            #+#    #+#             */
-/*   Updated: 2023/06/13 17:15:15 by yiwong           ###   ########.fr       */
+/*   Updated: 2023/06/14 00:15:16 by kschmidt         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -17,7 +17,7 @@ int	arg_check(int argc, char **argv)
 	int	error_code;
 
 	if (argc == 1)
-		return (0);
+		return (OK);
 	else if (argc >= 3)
 		return (ARGN);
 	error_code = map_check(argv[argc - 1]);

--- a/src/so_long.c
+++ b/src/so_long.c
@@ -6,7 +6,7 @@
 /*   By: yiwong <yiwong@student.42wolfsburg.de>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/06/10 15:16:58 by yiwong            #+#    #+#             */
-/*   Updated: 2023/06/13 19:16:00 by yiwong           ###   ########.fr       */
+/*   Updated: 2023/06/14 00:01:49 by kschmidt         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -14,8 +14,8 @@
 
 int	so_long(t_vars *vars)
 {
-	mlx_hook(vars->win, KeyPress, 1L << 0, key_pressed, &vars);
-	mlx_hook(vars->win, DestroyNotify, 0L, window_closed, &vars);
+	mlx_hook(vars->win, KeyPress, 1L << 0, key_pressed, vars);
+	mlx_hook(vars->win, DestroyNotify, 0L, window_closed, vars);
 	mlx_loop(vars->mlx);
 	return (0);
 }


### PR DESCRIPTION
oop


I also recommend to disable -g when -O3 or -Ofast is active because it'll make it harder to debug otherwise.

Don't enum, define.

Check for more errors, don't just implement random return codes you don't use.

You don't own the vars->mlx pointer. It's not yours. Don't act like it is yours. It is not.

There's more stuff that's dead ( :< ), but it won't lead you into issues ( :> ).